### PR TITLE
bug: fixed breaking of conditional logic characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To format a selected portion of the document, highlight the desired text, right-
 
 All notable changes to the "anyscript" extension will be documented here.
 
-### 0.2.4
+### 0.2.5
 
 #### Fixed
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ To format a selected portion of the document, highlight the desired text, right-
 
 All notable changes to the "anyscript" extension will be documented here.
 
+### 0.2.4
+
+#### Fixed
+
+- A bug in the formatter functions was fixed to avoid breaking conditional logic
+
 ### 0.2.3
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "anyscript",
   "displayName": "AnyScript",
   "description": "Language support for the AnyScript language",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "engines": {
     "vscode": "^1.81.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "anyscript",
   "displayName": "AnyScript",
   "description": "Language support for the AnyScript language",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "engines": {
     "vscode": "^1.81.0"
   },

--- a/src/intellisense/formatProvider.ts
+++ b/src/intellisense/formatProvider.ts
@@ -58,7 +58,7 @@ const separateEqualSign = (text: string) => {
   let insideMultiLineComment = false;
 
   return text.replace(
-    /(\/\*|\*\/|\/\/|["']|[=!<>]=|[?]{2}=|=)/g,
+    /(\/\*|\*\/|\/\/|["']|[=!<>]=|[?]{2}=|(?<!\s)=(?!\s))/g,
     (match, p1, offset, string) => {
       if (p1 === "/*") {
         insideMultiLineComment = true;

--- a/src/intellisense/formatProvider.ts
+++ b/src/intellisense/formatProvider.ts
@@ -52,9 +52,65 @@ const formatIndentation = (code: string, isSelection = false): string => {
 };
 
 const separateEqualSign = (text: string) => {
-  return text
-    .replace(/(\w+)(\s*([=!<>]=)\s*)(\w+)/g, "$1 $3 $4")
-    .replace(/(\w+)(\s*=\s*)(\w+)/g, "$1 = $3");
+  let insideSingleQuote = false;
+  let insideDoubleQuote = false;
+  let insideSingleLineComment = false;
+  let insideMultiLineComment = false;
+
+  return text.replace(
+    /(\/\*|\*\/|\/\/|["']|[=!<>]=|[?]{2}=|=)/g,
+    (match, p1, offset, string) => {
+      if (p1 === "/*") {
+        insideMultiLineComment = true;
+        return p1;
+      }
+      if (p1 === "*/") {
+        insideMultiLineComment = false;
+        return p1;
+      }
+      if (p1 === "//") {
+        insideSingleLineComment = true;
+        return p1;
+      }
+      if (p1 === "\n" && insideSingleLineComment) {
+        insideSingleLineComment = false;
+        return p1;
+      }
+      if (
+        p1 === "'" &&
+        !insideDoubleQuote &&
+        !insideSingleLineComment &&
+        !insideMultiLineComment
+      ) {
+        insideSingleQuote = !insideSingleQuote;
+        return p1;
+      }
+      if (
+        p1 === '"' &&
+        !insideSingleQuote &&
+        !insideSingleLineComment &&
+        !insideMultiLineComment
+      ) {
+        insideDoubleQuote = !insideDoubleQuote;
+        return p1;
+      }
+      if (
+        insideSingleQuote ||
+        insideDoubleQuote ||
+        insideSingleLineComment ||
+        insideMultiLineComment
+      ) {
+        return p1;
+      }
+      if (/[=!<>]=|[?]{2}=/.test(p1)) {
+        return ` ${p1} `;
+      }
+      if (p1 === "=") {
+        return " = ";
+      }
+      return p1;
+    }
+  );
 };
 
 export const formatDocumentProvider = (document: vscode.TextDocument) => {

--- a/src/intellisense/formatProvider.ts
+++ b/src/intellisense/formatProvider.ts
@@ -52,7 +52,9 @@ const formatIndentation = (code: string, isSelection = false): string => {
 };
 
 const separateEqualSign = (text: string) => {
-  return text.replace(/(\w+)(\s*=\s*)/g, "$1 = ");
+  return text
+    .replace(/(\w+)(\s*([=!<>]=)\s*)(\w+)/g, "$1 $3 $4")
+    .replace(/(\w+)(\s*=\s*)(\w+)/g, "$1 = $3");
 };
 
 export const formatDocumentProvider = (document: vscode.TextDocument) => {


### PR DESCRIPTION
I noticed that the formatter functions would separate ==, != and other conditional operators.
This is now fixed so it preserves them instead. 
0.2.4 is ready for release after this is merged